### PR TITLE
Don't use literate coffeescript while compiling for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "replay": "*"
   },
   "scripts": {
-    "pretest": "./node_modules/.bin/coffee -cl -o lib src",
+    "pretest": "./node_modules/.bin/coffee -c -o lib src",
     "test": "./node_modules/.bin/mocha"
   }
 }


### PR DESCRIPTION
This was failing for me. I am unsure how Travis was passing this
in the master branch.
