### PR TITLE
Added support for metric sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ var librato = require('librato-node');
 librato.increment('foo');
 ```
 
+Optionally a source can be specified for the metric.
+
+``` javascript
+var librato = require('librato-node');
+
+librato.increment('foo', {source: 'bar'});
+```
+
 ### Timing
 
 Use `librato.timing` to track durations in librato.
@@ -47,6 +55,14 @@ On each flush, the library sends a `count`, `sum`, `min`, `max`, and `sum_square
 var librato = require('librato-node');
 
 librato.timing('foo', 500);
+```
+
+Optionally a source can be specified for the metric.
+
+``` javascript
+var librato = require('librato-node');
+
+librato.timing('foo', 500, {source: 'bar'});
 ```
 
 ### Express

--- a/src/aggregator.coffee
+++ b/src/aggregator.coffee
@@ -1,4 +1,3 @@
-
 sum = (values) -> values.reduce (a, b) -> a + b
 max = (values) -> values.reduce (a, b) -> Math.max(a, b)
 min = (values) -> values.reduce (a, b) -> Math.min(a, b)
@@ -7,21 +6,25 @@ min = (values) -> values.reduce (a, b) -> Math.min(a, b)
 class Aggregator
   constructor: ->
     @cache = {}
-    
+
   flushTo: (queue) ->
-    for name, values of @cache
+    for key, values of @cache
+      [name, source] = key.split ';'
       values.sort()
-      queue.push
+      # queue.push
+      obj =
         name: name
         count: values.length
         sum: sum values
         max: max values
         min: min values
         sum_squares: sum values.map (value) -> Math.pow(value, 2)
-      delete @cache[name]
-    
+      obj.source = source  if source?
+      queue.push obj
+      delete @cache[key]
+
   timing: (name, value) ->
     (@cache[name] ?= []).push value
 
-    
+
 module.exports = Aggregator

--- a/src/counter_cache.coffee
+++ b/src/counter_cache.coffee
@@ -1,18 +1,17 @@
-
 class CounterCache
-  
+
   constructor: ->
     @cache = {}
-    
+
   flushTo: (queue) ->
-    for name, value of @cache
-      queue.push {name, value}
-      delete @cache[name]
-    
+    for key, value of @cache
+      [name, source] = key.split ';'
+      queue.push unless source? then {name, value} else {name, value, source}
+      delete @cache[key]
+
   increment: (name, value=1) ->
     @cache[name] ?= 0
     @cache[name] += value
 
 
 module.exports = CounterCache
-

--- a/test/aggregator.coffee
+++ b/test/aggregator.coffee
@@ -23,6 +23,15 @@ describe 'Aggregator', ->
       expect(foobar.sum).to.equal 300
       expect(foobar.sum_squares).to.equal 50000
 
+    it 'handles metrics with a source', ->
+      aggregator.timing('foobar;source', 100)
+      queue = []
+      aggregator.flushTo(queue)
+      expect(queue).to.have.length 1
+
+      foobar = queue[0]
+      expect(foobar.source).to.equal 'source'
+
     it 'handles multiple metrics', ->
       aggregator.timing('foo', 100)
       aggregator.timing('bar', 200)
@@ -55,4 +64,3 @@ describe 'Aggregator', ->
         queue = []
         aggregator.flushTo queue
         expect(queue).to.have.length 0
-

--- a/test/counter_cache.coffee
+++ b/test/counter_cache.coffee
@@ -4,7 +4,7 @@ CounterCache = require '../lib/counter_cache'
 
 describe 'CounterCache', ->
   {counter} = {}
-  
+
   beforeEach ->
     counter = new CounterCache()
 
@@ -16,7 +16,15 @@ describe 'CounterCache', ->
       counter.flushTo(queue)
       expect(queue).to.have.length 1
       expect(queue[0]).to.eql {name: 'foobar', value: 2}
-      
+
+    it 'counts metrics with a source', ->
+      counter.increment('foobar;source')
+      counter.increment('foobar;source')
+      queue = []
+      counter.flushTo(queue)
+      expect(queue).to.have.length 1
+      expect(queue[0]).to.eql {name: 'foobar', value: 2, source: 'source'}
+
     it 'counts multiple metrics', ->
       counter.increment('foo')
       counter.increment('bar')
@@ -27,15 +35,14 @@ describe 'CounterCache', ->
       expect(foo.value).to.equal 1
       bar = _(queue).find (item) -> item.name is 'bar'
       expect(bar.value).to.equal 1
-      
+
   describe '::flushTo', ->
     it 'clears the internal queue', ->
       counter.increment('foo')
       queue = []
       counter.flushTo queue
       expect(queue).to.have.length 1
-      
+
       queue = []
       counter.flushTo queue
       expect(queue).to.have.length 0
-

--- a/test/librato.coffee
+++ b/test/librato.coffee
@@ -41,6 +41,28 @@ describe 'librato', ->
       expect(names).to.contain 'messages'
       expect(values).to.contain 2
 
+    it 'accepts an additional source', ->
+      librato.increment('messages', {source: "source"})
+      librato.flush()
+      expect(Client::send.calledOnce).to.be true
+      args = Client::send.getCall(0).args
+      names = _(args[0].gauges).pluck('name').value()
+      source = _(args[0].gauges).pluck('source').value()
+      values = _(args[0].gauges).pluck('value').value()
+      expect(names).to.contain 'messages'
+      expect(values).to.contain 1
+
+    it 'accepts an additional source when incremented more than 1', ->
+      librato.increment('messages', 2, {source: "source"})
+      librato.flush()
+      expect(Client::send.calledOnce).to.be true
+      args = Client::send.getCall(0).args
+      names = _(args[0].gauges).pluck('name').value()
+      source = _(args[0].gauges).pluck('source').value()
+      values = _(args[0].gauges).pluck('value').value()
+      expect(names).to.contain 'messages'
+      expect(values).to.contain 2
+
   describe '::timing', ->
     it 'does not throw an error', ->
       librato.timing('foobar')


### PR DESCRIPTION
I made a new pull request to have it clean. This is a followup of #5. It supports the following API:

``` javascript
librato.increment 'foo', source: 'bar'
librato.increment 'foo', 23, source: 'bar'
librato.timing 'foo', 23, source: bar'
```
The tests are passing.