### PR TITLE
Handle counters and single value gauges

### DIFF
--- a/src/aggregator.coffee
+++ b/src/aggregator.coffee
@@ -10,14 +10,20 @@ class Aggregator
     
   flushTo: (queue) ->
     for name, values of @cache
-      values.sort()
-      queue.push
-        name: name
-        count: values.length
-        sum: sum values
-        max: max values
-        min: min values
-        sum_squares: sum values.map (value) -> Math.pow(value, 2)
+      if (values.length > 1)
+        values.sort()
+        queue.push
+          name: name
+          count: values.length
+          sum: sum values
+          max: max values
+          min: min values
+          sum_squares: sum values.map (value) -> Math.pow(value, 2)
+      else
+        queue.push
+          name: name
+          value: values[0]
+          
       delete @cache[name]
     
   timing: (name, value) ->

--- a/src/collector.coffee
+++ b/src/collector.coffee
@@ -13,9 +13,9 @@ class Collector
   timing: (args...) ->
     @aggregate.timing(args...)
 
-  flushTo: (queue) ->
-    @counters.flushTo(queue)
-    @aggregate.flushTo(queue)
+  flushTo: (counterQueue, aggregateQueue) ->
+    @counters.flushTo(counterQueue)
+    @aggregate.flushTo(aggregateQueue)
 
 module.exports = Collector
 

--- a/src/librato.coffee
+++ b/src/librato.coffee
@@ -32,12 +32,15 @@ librato.stop = (cb) ->
   librato.flush(cb)
 
 librato.flush = (cb = ->) ->
+  counters = []
   gauges = []
-  collector.flushTo gauges
-  measurement.source = config.source for measurement in gauges
-  return process.nextTick cb unless gauges.length
+  collector.flushTo counters, gauges
+  if config.source
+    measurement.source = config.source for measurement in counters
+    measurement.source = config.source for measurement in gauges
+  return process.nextTick cb unless counters.length or gauges.length
 
-  client.send {gauges}, (err) ->
+  client.send {counters, gauges}, (err) ->
     librato.emit 'error', err if err?
     cb(err)
 

--- a/test/aggregator.coffee
+++ b/test/aggregator.coffee
@@ -31,18 +31,10 @@ describe 'Aggregator', ->
       expect(queue).to.have.length 2
 
       foo = _(queue).find (item) -> item.name is 'foo'
-      expect(foo.count).to.equal 1
-      expect(foo.min).to.equal 100
-      expect(foo.max).to.equal 100
-      expect(foo.sum).to.equal 100
-      expect(foo.sum_squares).to.equal 10000
+      expect(foo.value).to.equal 100
 
       bar = _(queue).find (item) -> item.name is 'bar'
-      expect(bar.count).to.equal 1
-      expect(bar.min).to.equal 200
-      expect(bar.max).to.equal 200
-      expect(bar.sum).to.equal 200
-      expect(bar.sum_squares).to.equal 40000
+      expect(bar.value).to.equal 200
 
     describe '::flushTo', ->
       it 'clears the internal queue', ->

--- a/test/librato.coffee
+++ b/test/librato.coffee
@@ -17,8 +17,8 @@ describe 'librato', ->
       librato.flush()
       expect(Client::send.calledOnce).to.be true
       args = Client::send.getCall(0).args
-      names = _(args[0].gauges).pluck('name').value()
-      values = _(args[0].gauges).pluck('value').value()
+      names = _(args[0].counters).pluck('name').value()
+      values = _(args[0].counters).pluck('value').value()
       expect(names).to.contain 'this_is_:a_test_'
 
     it 'defaults increment to 1', ->
@@ -26,8 +26,8 @@ describe 'librato', ->
       librato.flush()
       expect(Client::send.calledOnce).to.be true
       args = Client::send.getCall(0).args
-      names = _(args[0].gauges).pluck('name').value()
-      values = _(args[0].gauges).pluck('value').value()
+      names = _(args[0].counters).pluck('name').value()
+      values = _(args[0].counters).pluck('value').value()
       expect(names).to.contain 'messages'
       expect(values).to.contain 1
 
@@ -36,8 +36,8 @@ describe 'librato', ->
       librato.flush()
       expect(Client::send.calledOnce).to.be true
       args = Client::send.getCall(0).args
-      names = _(args[0].gauges).pluck('name').value()
-      values = _(args[0].gauges).pluck('value').value()
+      names = _(args[0].counters).pluck('name').value()
+      values = _(args[0].counters).pluck('value').value()
       expect(names).to.contain 'messages'
       expect(values).to.contain 2
 
@@ -62,8 +62,9 @@ describe 'librato', ->
     it 'sends data to Librato', ->
       expect(Client::send.calledOnce).to.be true
       args = Client::send.getCall(0).args
-      names = _(args[0].gauges).pluck('name').value()
+      names = _(args[0].counters).pluck('name').value()
       expect(names).to.contain 'foo'
+      names = _(args[0].gauges).pluck('name').value()
       expect(names).to.contain 'bar'
 
 


### PR DESCRIPTION
Counter type metrics were being sent as gauges. This fixes things so that they're sent as the counter metric type. That impacts how `increment` results are recorded. I also simplified the data to send for gauges that only have one value. According to the Librato documentation, only `name` and `value` are needed in that instance.