### PR TITLE
Add a failing test that a Librato failure does not crash the client

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -10,7 +10,7 @@ class Client
       console.warn "librato-node metrics disabled: no email or token provided." unless simulate
     else
       @_authHeader = 'Basic ' + new Buffer("#{email}:#{token}").toString('base64')
-    
+
   send: (json, cb) ->
     return cb() unless @_authHeader
     requestOptions =
@@ -20,13 +20,12 @@ class Client
       headers:
         authorization: @_authHeader
         'user-agent': 'librato-node/'+ packageJson.version
-        
+
     request requestOptions, (err, res, body) ->
       return cb(err) if err?
       if res.statusCode > 399 or body?.errors?
         return cb(new Error("Error sending to Librato: #{util.inspect(body)} (statusCode: #{res.statusCode})"))
       return cb(null, body)
 
-    
-module.exports = Client
 
+module.exports = Client

--- a/src/librato.coffee
+++ b/src/librato.coffee
@@ -25,10 +25,10 @@ librato.measure = (name, value) ->
 librato.timing = (name, fn) ->
   name = sanitize_name(name)
   collector.timing "#{config.prefix ? ''}#{name}", fn
-    
+
 librato.start = ->
   worker.start()
-    
+
 librato.stop = (cb) ->
   worker.stop()
   librato.flush(cb)
@@ -52,4 +52,3 @@ module.exports = librato
 # https://github.com/librato/statsd-librato-backend/blob/dffece631fcdc4c94b2bff1f7526486aa5bfbab9/lib/librato.js#L144
 sanitize_name = (name) ->
   return name.replace(/[^-.:_\w]+/g, '_').substr(0,255)
-

--- a/src/worker.coffee
+++ b/src/worker.coffee
@@ -1,13 +1,13 @@
 
 class Worker
-  
+
   period: 60000
-  
+
   constructor: ({@job, period}={}) ->
     throw new Error('must provide job') unless @job?
     @period = period if period?
     @stopped = true
-    
+
   start: ->
     @stopped = false
     nextRun = Worker.startTime(@period)
@@ -20,12 +20,12 @@ class Worker
         else
           return (@timerId = setTimeout workFn, (nextRun - now))
     workFn()
-  
+
   stop: ->
     return if @stopped
     @stopped = true
     clearTimeout @timerId if @timerId?
-    
+
   # Give some structure to worker start times so when possible they will be in sync.
   @startTime: (period) ->
     earliest = new Date(Date.now() + period)
@@ -40,4 +40,3 @@ class Worker
 
 
 module.exports = Worker
-

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -5,20 +5,19 @@ describe 'Client', ->
   {client} = {}
 
   describe 'with email and token', ->
-  
+
     beforeEach ->
       client = new Client email: 'foo@example.com', token: 'bob'
-      
+
     describe '::send', ->
       it 'sends data to Librato', (done) ->
         client.send {gauges: [{name: 'foo', value: 1}]}, done
 
   describe 'in simulate mode', ->
-  
+
     beforeEach ->
       client = new Client simulate: true
-      
+
     describe '::send', ->
       it 'sends data to Librato', (done) ->
         client.send {gauges: [{name: 'foo', value: 1}]}, done
-

--- a/test/librato.coffee
+++ b/test/librato.coffee
@@ -3,13 +3,22 @@ _ = require 'lodash'
 Client = require '../lib/client'
 librato = require '..'
 
+libratoError = new Error 'error sending data: {} 500'
+
 describe 'librato failure', ->
   beforeEach ->
     librato.configure email: 'foo@example.com', token: 'foobar'
     sinon.stub Client::, 'send', (data, cb) ->
-      cb new Error 'error sending data: {} 500'
+      cb libratoError
 
   it 'does not crash the client', (done) ->
+    librato.increment('messages')
+    librato.flush()
+
+  it 'handles emitted errors', (done) ->
+    librato.on 'error', (err) ->
+      expect(err).to.equal libratoError
+      done()
     librato.increment('messages')
     librato.flush()
 

--- a/test/librato.coffee
+++ b/test/librato.coffee
@@ -3,6 +3,17 @@ _ = require 'lodash'
 Client = require '../lib/client'
 librato = require '..'
 
+describe 'librato failure', ->
+  beforeEach ->
+    librato.configure email: 'foo@example.com', token: 'foobar'
+    sinon.stub Client::, 'send', (data, cb) ->
+      cb new Error 'error sending data: {} 500'
+
+  it 'does not crash the client', (done) ->
+    librato.increment('messages')
+    librato.flush()
+
+
 describe 'librato', ->
   beforeEach ->
     librato.configure email: 'foo@example.com', token: 'foobar'


### PR DESCRIPTION
If Librato returns a server error, the background worker crashes. This is probably not desired behavior, but I'm not sure what it should do instead. I added a failing test to expose this.

I'm a little confused about the mechanism as well, since librato.flush() with zero arguments makes the callback an empty function. Continuing to dig.
