### PR TITLE
Make UA compatible with librato-rack

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -16,7 +16,7 @@ class Client
         headers: {}
       @_requestOptions.headers = _.defaults @_requestOptions.headers,
         authorization: 'Basic ' + new Buffer("#{email}:#{token}").toString('base64')
-        'user-agent': "librato-rack (compatible; librato-node/#{packageJson.version})"
+        'user-agent': "librato-rack/0.4.5 (compatible; librato-node/#{packageJson.version})"
 
   send: (json, cb) ->
     return process.nextTick(cb) unless @_requestOptions?

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -16,7 +16,7 @@ class Client
         headers: {}
       @_requestOptions.headers = _.defaults @_requestOptions.headers,
         authorization: 'Basic ' + new Buffer("#{email}:#{token}").toString('base64')
-        'user-agent': "librato-node/#{packageJson.version}"
+        'user-agent': "librato-rack (compatible; librato-node/#{packageJson.version})"
 
   send: (json, cb) ->
     return process.nextTick(cb) unless @_requestOptions?


### PR DESCRIPTION
Librato looks at the useragent string and does things slightly differently for the librato-rack lib (among others). One thing is that they automatically enable [service side aggregation](http://support.metrics.librato.com/knowledgebase/articles/213775-what-is-service-side-aggregation-ssa) (see the second-to-the-last section).

I'm definitely going to want this feature, and I think it would be good to have functional parity with librato-rack.
